### PR TITLE
Added some options to burst capture mode (see below)

### DIFF
--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -101,6 +101,7 @@ export class Camera {
       ];
       !!forceOverwrite && args.push(`--force-overwrite`)
       !!filename && args.push(`--filename=${filename}%n.%C`);
+      captureTarget === 1 && args.push(`--get-all-files`)
       deleteAllFiles && args.push(`-f`) && args.push(`/`) && args.push(`--delete-all-files`) && args.push(`--recurse`)
       this._process = this.spawn(args, callbacks);
     } else {

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -87,7 +87,7 @@ export class Camera {
   }
 
   public burst = (
-    { length, filename, burstMode, forceOverwrite, captureTarget }: BurstOptions,
+    { length, filename, burstMode, forceOverwrite, captureTarget, deleteAllFiles }: BurstOptions,
     callbacks?: Callbacks
   ) => {
     if (this.model.startsWith("Canon")) {
@@ -101,6 +101,7 @@ export class Camera {
       ];
       !!forceOverwrite && args.push(`--force-overwrite`)
       !!filename && args.push(`--filename=${filename}%n.%C`);
+      deleteAllFiles && args.push(`-f`) && args.push(`/`) && args.push(`--delete-all-files`) && args.push(`--recurse`)
       this._process = this.spawn(args, callbacks);
     } else {
       callbacks?.onError &&

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -97,7 +97,7 @@ export class Camera {
         `--set-config=eosremoterelease=2`,
         `--wait-event-and-download=${length}s`,
         `--set-config=eosremoterelease=4`,
-        `--wait-event=1s`
+        `--wait-event=CAPTURECOMPLETE`
       ];
       !!forceOverwrite && args.push(`--force-overwrite`)
       !!filename && args.push(`--filename=${filename}%n.%C`);

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -87,18 +87,19 @@ export class Camera {
   }
 
   public burst = (
-    { length, filename }: BurstOptions,
+    { length, filename, burstMode, forceOverwrite, captureTarget }: BurstOptions,
     callbacks?: Callbacks
   ) => {
     if (this.model.startsWith("Canon")) {
       const args = [
-        `--set-config=capturetarget=0`,
-        `--set-config=drivemode=2`,
+        `--set-config=capturetarget=${ captureTarget === undefined ? 0 : captureTarget}`,
+        `--set-config=drivemode=${burstMode === undefined ? 2 : burstMode}`,
         `--set-config=eosremoterelease=2`,
         `--wait-event-and-download=${length}s`,
         `--set-config=eosremoterelease=4`,
         `--wait-event=1s`
       ];
+      !!forceOverwrite && args.push(`--force-overwrite`)
       !!filename && args.push(`--filename=${filename}%n.%C`);
       this._process = this.spawn(args, callbacks);
     } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,4 +33,4 @@ export type CaptureOptions = Partial<{
   skipExisting: boolean;
 }>;
 
-export type BurstOptions = { length: number, filename?: string };
+export type BurstOptions = { burstMode?: number, captureTarget: number, length: number, filename?: string, forceOverwrite?: boolean };

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,4 +33,4 @@ export type CaptureOptions = Partial<{
   skipExisting: boolean;
 }>;
 
-export type BurstOptions = { burstMode?: number, captureTarget: number, length: number, filename?: string, forceOverwrite?: boolean };
+export type BurstOptions = { captureTarget: number, length: number, burstMode?: number,  deleteAllFiles?: boolean, filename?: string, forceOverwrite?: boolean };


### PR DESCRIPTION
I added the following options:

- captureTarget: allows one to select wether pictures are saved in
  internal memory or on storage card. Internal memory can be too small
to store capture pictures resulting on PTP errors preventing us to do
more captures
- forceOverwrite: allows overwriting existing files if any (without this
  and with existing pictures on disk the next captures was failing
because gphoto2 requested a user input in interactive shell asking if it
is allowed to overwrite existing files)
- burstMode: allow using fast or slow burst mode instead of slow mode
  only